### PR TITLE
Adding option to republish a SNS message back to its topic of origin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 build/sqs-grep*
 coverage
+.idea

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sqs-grep",
-  "version": "1.6.1",
+  "version": "1.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4657,6 +4657,17 @@
                 "pac-resolver": "^3.0.0",
                 "raw-body": "^2.2.0",
                 "socks-proxy-agent": "^4.0.1"
+              },
+              "dependencies": {
+                "https-proxy-agent-snyk-fork": {
+                  "version": "git://github.com/snyk/node-https-proxy-agent.git#5e86ccb682d0c833c8daa25ee6f91c670161cd66",
+                  "from": "git://github.com/snyk/node-https-proxy-agent.git#fix/https-agent-vuln",
+                  "dev": true,
+                  "requires": {
+                    "agent-base": "^4.3.0",
+                    "debug": "^3.1.0"
+                  }
+                }
               }
             },
             "pac-resolver": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqs-grep",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Greps AWS SQS messages from the command-line, optionally moving or deleting them",
   "main": "index.js",
   "bin": {

--- a/readme.md
+++ b/readme.md
@@ -95,6 +95,7 @@ Main options
   --moveTo queue name           Move matched messages to the given destination queue                          
   --copyTo queue name           Copy matched messages to the given destination queue                          
   --publishTo topic ARN         Publish matched messages to the given destination SNS topic                   
+  --republish                   Republishes matched messages from SNS back to their topic of origin
   --all                         Matches all messages in the queue (do not filter anything). Setting this flag 
                                 overrides --body and --attribute                                              
 

--- a/readme.md
+++ b/readme.md
@@ -77,7 +77,7 @@ $ sqs-grep --accessKeyId "KEY" --secretAccessKey "SECRET" <other options>
 ```
 $ sqs-grep --help
 
-sqs-grep version 1.8.0
+sqs-grep version 1.8.1
 
 sqs-grep
 

--- a/src/main.js
+++ b/src/main.js
@@ -9,7 +9,7 @@ const {SqsGrep} = require('./sqs-grep');
  */
 async function main() {
     const options = parseOptions();
-    await fillInputCredentials(options)
+    await fillInputCredentials(options);
     const sqsGrep = new SqsGrep(options);
     // Graceful stop on interrupt signal (CTRL+C for example)
     process.on('SIGINT', () => {

--- a/src/options.js
+++ b/src/options.js
@@ -26,6 +26,7 @@ const optionDefinitions = [
     { name: 'moveTo', typeLabel: '{underline queue name}', group: 'main', description: 'Move matched messages to the given destination queue' },
     { name: 'copyTo', typeLabel: '{underline queue name}', group: 'main', description: 'Copy matched messages to the given destination queue' },
     { name: 'publishTo', typeLabel: '{underline topic ARN}', group: 'main', description: 'Publish matched messages to the given destination SNS topic' },
+    { name: 'republish', type: Boolean, group: 'main', description: 'Republish messages that originated from SNS back to their topic of origin' },
     { name: 'all', type: Boolean, group: 'main', description: 'Matches all messages in the queue (do not filter anything). Setting this flag overrides {bold --body} and {bold --attribute}' },
     // Credentials
     { name: 'inputCredentials', alias: 'i', type: Boolean, description: 'Input the AWS access key id and secret access key via {underline stdin}', group: 'credentials' },
@@ -133,9 +134,9 @@ function validateOptions(options, log) {
     }
     const error = msg => {
         log(msg);
-        log(chalk`{italic (See all options by specifying {bold --help} in the command-line)}`)
+        log(chalk`{italic (See all options by specifying {bold --help} in the command-line)}`);
         return false;
-    }
+    };
     if (!options.queue) {
         return error(chalk`{red ERROR: You must specify {bold --queue}}`);
     }

--- a/src/sqs-grep.js
+++ b/src/sqs-grep.js
@@ -95,7 +95,7 @@ class SqsGrep {
         });
         // Wait for all parallel executions to complete
         await Promise.all(promises);
-    
+
         // Print the status
         this.log(chalk`\nMessages scanned: {green ${this.qtyScanned}}\nMessages matched: {green ${this.qtyMatched}}`);
         if (!this.running) this.log('Interrupted');
@@ -140,7 +140,7 @@ class SqsGrep {
      * Connects to all required SQS queues by retrieving their URL
      */
     async _connectToQueues() {
-        this.log(chalk`Connecting to SQS queue '{green ${this.options.queue}}' in the '{green ${this.options.region}}' region...`)
+        this.log(chalk`Connecting to SQS queue '{green ${this.options.queue}}' in the '{green ${this.options.region}}' region...`);
         this.options.sourceQueueUrl = (await this.sqs.getQueueUrl({
             QueueName: this.options.queue,
         }).promise()).QueueUrl;
@@ -207,7 +207,7 @@ class SqsGrep {
             Body: message.Body,
             MessageAttributes: message.MessageAttributes
         }) : message.Body;
-        
+
         if (options.outputFile) {
             return new Promise((resolve, reject) => {
                 fs.appendFile(options.outputFile, content + os.EOL, {encoding: 'utf-8'}, err => {
@@ -227,7 +227,7 @@ class SqsGrep {
     async _processMatchedSqsMessage(message) {
         await this._printSqsMessage(message);
         const options = this.options;
-        if (options.moveTo || options.copyTo || options.publishTo) {
+        if (options.moveTo || options.copyTo || options.publishTo || options.republish) {
             if (!options.stripAttributes && message.MessageAttributes) {
                 // Remove parameter values not supported yet
                 for (let key in message.MessageAttributes) {
@@ -251,6 +251,17 @@ class SqsGrep {
                     Message: this._getBodyToPublish(message),
                     MessageAttributes: options.stripAttributes ? null : message.MessageAttributes,
                 }).promise();
+            }
+            // Republish message to it's topic of origin
+            if (options.republish) {
+                const notification = JSON.parse(message.Body);
+                if (notification.Type === 'Notification' && notification.Message) {
+                    await this.sns.publish({
+                        TopicArn: notification.TopicArn,
+                        Message: notification.Message,
+                        MessageAttributes: options.stripAttributes ? null : message.MessageAttributes,
+                    }).promise();
+                }
             }
         }
         if (options.delete || options.moveTo) {

--- a/src/sqs-grep.js
+++ b/src/sqs-grep.js
@@ -254,13 +254,17 @@ class SqsGrep {
             }
             // Republish message to it's topic of origin
             if (options.republish) {
-                const notification = JSON.parse(message.Body);
-                if (notification.Type === 'Notification' && notification.Message) {
-                    await this.sns.publish({
-                        TopicArn: notification.TopicArn,
-                        Message: notification.Message,
-                        MessageAttributes: options.stripAttributes ? null : message.MessageAttributes,
-                    }).promise();
+                try {
+                    const notification = JSON.parse(message.Body);
+                    if (notification.Type === 'Notification' && notification.Message && notification.TopicArn) {
+                        await this.sns.publish({
+                            TopicArn: notification.TopicArn,
+                            Message: notification.Message,
+                            MessageAttributes: options.stripAttributes ? null : message.MessageAttributes,
+                        }).promise();
+                    }
+                } catch (err) {
+                    // ignore
                 }
             }
         }


### PR DESCRIPTION
SQS messages published by SNS (when not raw) contain the Topic Arn for their topic of origin.

There are cases where multiple topics can publish messages to the same SQS queue, which would be difficult to republish with the current publishTo implementation.

This new operation allows these messages to be republished to their topic of origin automatically.