### PR TITLE
Fix SNS message attributes when publishing or republishing to topic

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqs-grep",
-  "version": "1.14.1",
+  "version": "1.14.2",
   "description": "Greps AWS SQS messages from the command-line, optionally moving or deleting them",
   "main": "index.js",
   "bin": {

--- a/test/test-sqs-grep.js
+++ b/test/test-sqs-grep.js
@@ -640,6 +640,40 @@ describe('SqsGrep', function () {
             assert.equal(res.qtyMatched, 2);
         });
 
+        it('should publish SNS notification with message attributes', async function () {
+            // arrange
+            const options = parse(['--queue=A', '--all', '--publishTo=FAKE_ARN']);
+            const sqsGrep = new SqsGrep(options);
+            sqs.receiveMessage.onFirstCall().returns({
+                promise: () => Promise.resolve({Messages: [
+                    {Body: '{"Type":"Notification","Message":"1","MessageAttributes":{"key":{"Value":"val","Type": "type"}}}'},
+                    {Body: '2', MessageAttributes:{key: {StringValue: 'val', DataType: 'type'}}},
+                ]})
+            });
+            [1,2,3,4,5,6].forEach(call => {
+                sqs.receiveMessage.onCall(call).returns({
+                    promise: () => Promise.resolve({Messages: []})
+                });
+            });
+            
+            // act
+            const res = await sqsGrep.run();
+
+            // assert
+            assert.equal(sqs.getQueueUrl.callCount, 1);
+            assert.equal(sns.getTopicAttributes.callCount, 1);
+            assert.equal(sns.publish.callCount, 2);
+            assert.equal(sns.publish.firstCall.args[0].Message, '1');
+            assert.equal(sns.publish.firstCall.args[0].MessageAttributes.key.StringValue, 'val');
+            assert.equal(sns.publish.firstCall.args[0].MessageAttributes.key.DataType, 'type');
+            assert.equal(sns.publish.secondCall.args[0].Message, '2');
+            assert.equal(sns.publish.secondCall.args[0].MessageAttributes.key.StringValue, 'val');
+            assert.equal(sns.publish.secondCall.args[0].MessageAttributes.key.DataType, 'type');
+            assert.equal(sqs.deleteMessage.callCount, 0);
+            assert.equal(res.qtyScanned, 2);
+            assert.equal(res.qtyMatched, 2);
+        });
+
         it('should publish messages stripping attributes', async function () {
             // arrange
             const options = parse(['--queue=A', '--all', '--publishTo=FAKE_ARN', '--stripAttributes']);
@@ -701,13 +735,47 @@ describe('SqsGrep', function () {
             assert.equal(res.qtyMatched, 2);
         });
 
+        it('should republish SNS messages with message attributes', async function () {
+            // arrange
+            const options = parse(['--queue=A', '--all', '--republish']);
+            const sqsGrep = new SqsGrep(options);
+            sqs.receiveMessage.onFirstCall().returns({
+                promise: () => Promise.resolve({Messages: [
+                        {Body: '{"Type":"Notification","Message":"1", "TopicArn":"A", "MessageAttributes":{"key":{"Value":"val","Type": "type"}}}'},
+                        {Body: '{"Type":"Notification","Message":"2", "TopicArn":"B"}'},
+                    ]})
+            });
+            [1,2,3,4,5,6].forEach(call => {
+                sqs.receiveMessage.onCall(call).returns({
+                    promise: () => Promise.resolve({Messages: []})
+                });
+            });
+
+            // act
+            const res = await sqsGrep.run();
+
+            // assert
+            assert.equal(sqs.getQueueUrl.callCount, 1);
+            assert.equal(sns.publish.callCount, 2);
+            assert.equal(sns.publish.firstCall.args[0].Message, '1');
+            assert.equal(sns.publish.firstCall.args[0].TopicArn, 'A');
+            assert.equal(sns.publish.firstCall.args[0].MessageAttributes.key.StringValue, 'val');
+            assert.equal(sns.publish.firstCall.args[0].MessageAttributes.key.DataType, 'type');
+            assert.equal(sns.publish.secondCall.args[0].Message, '2');
+            assert.equal(sns.publish.secondCall.args[0].TopicArn, 'B');
+            assert.equal(sns.publish.secondCall.args[0].MessageAttributes, null);
+            assert.equal(sqs.deleteMessage.callCount, 0);
+            assert.equal(res.qtyScanned, 2);
+            assert.equal(res.qtyMatched, 2);
+        });
+
         it('should republish SNS messages stripping attributes', async function () {
             // arrange
             const options = parse(['--queue=A', '--all', '--republish', '--stripAttributes']);
             const sqsGrep = new SqsGrep(options);
             sqs.receiveMessage.onFirstCall().returns({
                 promise: () => Promise.resolve({Messages: [
-                        {Body: '{"Type":"Notification","Message":"1", "TopicArn":"A"}', MessageAttributes:{key: {StringValue: 'val'}}},
+                        {Body: '{"Type":"Notification","Message":"1", "TopicArn":"A", "MessageAttributes":{"key":{"Value":"val","Type": "type"}}}'},
                         {Body: '{"Type":"Notification","Message":"2", "TopicArn":"B"}'},
                     ]})
             });


### PR DESCRIPTION
Fix issue when `sqs-grep` is creating SNS request object with message attribute. The current request object is getting message attribute from SQS message instead of SNS notification. 

### Tests
- `npm run integration-test`