### PR TITLE
Adding option for AWS session token

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -33,6 +33,7 @@ const optionDefinitions = [
     { name: 'inputCredentials', alias: 'i', type: Boolean, description: 'Input the AWS access key id and secret access key via {underline stdin}', group: 'credentials' },
     { name: 'accessKeyId', description: 'AWS access key id ({bold not recommended:} use "aws configure" or "--inputCredentials" instead)', group: 'credentials' },
     { name: 'secretAccessKey', description: 'AWS secret access key ({bold not recommended:} use "aws configure" or "--inputCredentials" instead)', group: 'credentials' },
+    { name: 'sessionToken', description: 'AWS session token', group: 'credentials' },
     // Other
     { name: 'negate', alias: 'n', type: Boolean, defaultValue: false, description: 'Negates the result of the pattern matching\n(I.e.: to find messages NOT containing a text)' },
     { name: 'timeout', alias: 't', type: Number, defaultValue: 60, typeLabel: '{underline seconds}', description: 'Timeout for the whole operation to complete.\nThe message visibility timeout will be calculated based on this value as well and the elapsed time to ensure that messages become visible again as soon as possible.' },

--- a/src/sqs-grep.js
+++ b/src/sqs-grep.js
@@ -186,6 +186,9 @@ class SqsGrep {
         if (options.secretAccessKey) {
             opts.secretAccessKey = options.secretAccessKey;
         }
+        if (options.sessionToken) {
+            opts.sessionToken = options.sessionToken;
+        }
         if (options.endpointUrl) {
             opts.endpoint = new AWS.Endpoint(options.endpointUrl);
         }

--- a/test/test-sqs-grep.js
+++ b/test/test-sqs-grep.js
@@ -107,6 +107,11 @@ describe('SqsGrep', function () {
             const opts = SqsGrep._getAwsOptions(options);
             assert.equal(opts.secretAccessKey, 'SECRET');
         });
+        it('should set the sessionToken', async function () {
+            const options = parse(['--sessionToken', 'TOKEN']);
+            const opts = SqsGrep._getAwsOptions(options);
+            assert.equal(opts.sessionToken, 'TOKEN');
+        });
         it('should set the endpointUrl', async function () {
             const options = parse(['--endpointUrl', 'http://localhost:5000']);
             const opts = SqsGrep._getAwsOptions(options);


### PR DESCRIPTION
Adding option for AWS session token that must be set when using credentials from an assumed role.